### PR TITLE
Adjust the default busy thread settings to avoid background termination

### DIFF
--- a/Base/Config.hpp
+++ b/Base/Config.hpp
@@ -25,8 +25,11 @@
 #include <chrono>
 
 constexpr auto kDefaultNumBusyThreads = 0;
-constexpr auto kDefaultBusyThreadPeriod = std::chrono::milliseconds{15};
-constexpr auto kDefaultBusyThreadCpuUsage = 0.66;
+
+// These settings are tuned to ramp up CPUs without exceeding the background CPU usage
+// limit. See the README for more information.
+constexpr auto kDefaultBusyThreadPeriod = std::chrono::milliseconds{35};
+constexpr auto kDefaultBusyThreadCpuUsage = 0.5;
 
 constexpr auto kDefaultNumWorkerThreads = 1;
 


### PR DESCRIPTION
With the old settings, the app would be terminated within 15 seconds when
running in the background with audio input enabled due to the busy thread
exceeding the CPU usage limit. With the new settings, the app can run
indefinitely as long as audio threads stay under the limit as well.

Increasing the busy thread period allows the CPU usage to be lowered without
changing the transient response or energy usage.