### PR TITLE
Fix two UI issues

### DIFF
--- a/AudioPerfLab/FreezeSwitch.swift
+++ b/AudioPerfLab/FreezeSwitch.swift
@@ -49,6 +49,7 @@ class FreezeSwitchView: UILabel {
     shapeLayer.lineWidth = 1.1
     shapeLayer.strokeColor = tintColor.cgColor
     shapeLayer.fillColor = nil
+    shapeLayer.zPosition = -1.0
     layer.addSublayer(shapeLayer)
   }
 

--- a/AudioPerfLab/Info.plist
+++ b/AudioPerfLab/Info.plist
@@ -26,6 +26,8 @@
 	</array>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Testing with audio input</string>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
Opt out of Dark Mode until we properly support it (see https://github.com/Ableton/AudioPerfLab/issues/12) and make the snowflake icon visible when visualizations are frozen.