### PR TITLE
Improve support for iPad Pro

### DIFF
--- a/AudioPerfLab/Constants.hpp
+++ b/AudioPerfLab/Constants.hpp
@@ -25,7 +25,7 @@
 #include <chrono>
 #include <initializer_list>
 
-constexpr auto kDefaultNumSines = 36;
+constexpr auto kDefaultNumSines = 18;
 constexpr auto kAmpSmoothingDuration = std::chrono::milliseconds{100};
 
 /* The number of partials taken at a time by worker threads.
@@ -40,9 +40,8 @@ constexpr auto kAmpSmoothingDuration = std::chrono::milliseconds{100};
  */
 constexpr auto kNumPartialsPerProcessingChunk = 256;
 
-// Play every note twice to increase load
-constexpr auto kChordNoteNumbers = {53.0f, 53.0f, 56.0f, 56.0f, 60.0f, 60.0f};
-constexpr auto kNumUnrandomizedPhases = 30;
+constexpr auto kChordNoteNumbers = {53.0f, 56.0f, 60.0f};
+constexpr auto kNumUnrandomizedPhases = 15;
 
 constexpr auto kDriveMeasurementQueueSize = 1024;
 constexpr auto kMaxNumFrames = 4096;

--- a/AudioPerfLab/Constants.hpp
+++ b/AudioPerfLab/Constants.hpp
@@ -40,7 +40,7 @@ constexpr auto kAmpSmoothingDuration = std::chrono::milliseconds{100};
  */
 constexpr auto kNumPartialsPerProcessingChunk = 256;
 
-constexpr auto kChordNoteNumbers = {53.0f, 56.0f, 60.0f};
+constexpr auto kChordNoteNumbers = {53.0f, 56.0f, 60.0f, 65.0f};
 constexpr auto kNumUnrandomizedPhases = 15;
 
 constexpr auto kDriveMeasurementQueueSize = 1024;

--- a/AudioPerfLab/Engine.hpp
+++ b/AudioPerfLab/Engine.hpp
@@ -48,7 +48,8 @@ typedef NS_ENUM(NSInteger, PerformancePreset) {
 @property(nonatomic, readonly) float outputVolume;
 @property(nonatomic) int preferredBufferSize;
 @property(nonatomic, readonly) double sampleRate;
-@property(nonatomic) int numWorkerThreads;
+@property(nonatomic, readonly) int numWorkerThreads;
+@property(nonatomic) int numProcessingThreads;
 @property(nonatomic) int numBusyThreads;
 @property(nonatomic) double busyThreadPeriod;
 @property(nonatomic) double busyThreadCpuUsage;

--- a/AudioPerfLab/Engine.hpp
+++ b/AudioPerfLab/Engine.hpp
@@ -24,7 +24,7 @@
 
 #import <UIKit/UIKit.h>
 
-#define MAX_NUM_THREADS 8
+#define MAX_NUM_THREADS 32
 struct DriveMeasurement
 {
   double hostTime;

--- a/AudioPerfLab/Engine.mm
+++ b/AudioPerfLab/Engine.mm
@@ -158,13 +158,9 @@ private:
     driveMeasurement.duration =
       std::chrono::duration<double>{bufferEndTime - bufferStartTime}.count();
     driveMeasurement.numFrames = numFrames;
-    std::fill_n(driveMeasurement.numActivePartialsProcessed, MAX_NUM_THREADS, -1);
-    std::fill_n(driveMeasurement.cpuNumbers, MAX_NUM_THREADS, -1);
-    for (int i = 0; i < mHost.numWorkerThreads() + 1; ++i)
-    {
-      driveMeasurement.numActivePartialsProcessed[i] = mNumActivePartialsProcessed[i];
-      driveMeasurement.cpuNumbers[i] = mCpuNumbers[i];
-    }
+    std::copy(mNumActivePartialsProcessed.begin(), mNumActivePartialsProcessed.end(),
+              driveMeasurement.numActivePartialsProcessed);
+    std::copy(mCpuNumbers.begin(), mCpuNumbers.end(), driveMeasurement.cpuNumbers);
     driveMeasurement.inputPeakLevel = inputPeakLevel;
     mDriveMeasurements.tryPushBack(driveMeasurement);
   }
@@ -175,11 +171,8 @@ private:
     assertRelease((numWorkerThreads + 1) <= MAX_NUM_THREADS, "Too many worker threads");
 
     mSineBank.setNumThreads(numWorkerThreads + 1);
-    for (int i = 1; i <= numWorkerThreads; ++i)
-    {
-      mNumActivePartialsProcessed[i] = -1;
-      mCpuNumbers[i] = -1;
-    }
+    std::fill(mNumActivePartialsProcessed.begin(), mNumActivePartialsProcessed.end(), -1);
+    std::fill(mCpuNumbers.begin(), mCpuNumbers.end(), -1);
   }
 
   // Called at the start of the audio I/O callback with no worker threads active

--- a/AudioPerfLab/Engine.mm
+++ b/AudioPerfLab/Engine.mm
@@ -169,7 +169,8 @@ private:
   void setup(const int numProcessingThreads)
   {
     assertRelease(
-      (numProcessingThreads + 1) <= MAX_NUM_THREADS, "Too many processing threads");
+      numProcessingThreads > 0 && (numProcessingThreads + 1) <= MAX_NUM_THREADS,
+      "Invalid number of threads");
 
     mSineBank.setNumThreads(numProcessingThreads);
     std::fill(mNumActivePartialsProcessed.begin(), mNumActivePartialsProcessed.end(), -1);

--- a/AudioPerfLab/ParallelSineBank.cpp
+++ b/AudioPerfLab/ParallelSineBank.cpp
@@ -22,12 +22,15 @@
 
 #include "ParallelSineBank.hpp"
 
+#include "Base/Assert.hpp"
 #include "Constants.hpp"
 
 #include <algorithm>
 
 void ParallelSineBank::setNumThreads(const int numThreads)
 {
+  assertRelease(numThreads >= 0, "Invalid number of threads");
+
   mBuffers.resize(numThreads, StereoAudioBuffer{std::vector<float>(kMaxNumFrames, 0.0f),
                                                 std::vector<float>(kMaxNumFrames, 0.0f)});
 }
@@ -40,6 +43,9 @@ void ParallelSineBank::setPartials(std::vector<Partial> partials)
 
 void ParallelSineBank::prepare(const int numActivePartials, const int numFrames)
 {
+  assertRelease(numActivePartials >= 0, "Invalid number of active partials");
+  assertRelease(numFrames > 0 && numFrames <= kMaxNumFrames, "Invalid number of frames");
+
   mNumActivePartials = numActivePartials;
   mNumTakenPartials = 0;
 
@@ -52,6 +58,10 @@ void ParallelSineBank::prepare(const int numActivePartials, const int numFrames)
 
 int ParallelSineBank::process(const int threadIndex, const int numFrames)
 {
+  assertRelease(
+    threadIndex >= 0 && threadIndex < int(mBuffers.size()), "Invalid thread index");
+  assertRelease(numFrames > 0 && numFrames <= kMaxNumFrames, "Invalid number of frames");
+
   auto& stereoBuffer = mBuffers[threadIndex];
 
   int numActivePartialsProcessed = 0;
@@ -83,6 +93,8 @@ int ParallelSineBank::process(const int threadIndex, const int numFrames)
 
 void ParallelSineBank::mixTo(const StereoAudioBufferPtrs dest, const int numFrames)
 {
+  assertRelease(numFrames > 0 && numFrames <= kMaxNumFrames, "Invalid number of frames");
+
   const auto sumInto = [](const auto& inBuffer, auto* pOutBuffer, const int numFrames) {
     std::transform(inBuffer.begin(), inBuffer.begin() + numFrames, pOutBuffer, pOutBuffer,
                    [](const float x, const float y) { return x + y; });

--- a/AudioPerfLab/ViewController.swift
+++ b/AudioPerfLab/ViewController.swift
@@ -62,6 +62,8 @@ class ViewController: UITableViewController {
   @IBOutlet weak private var processInDriverThreadControl: UISegmentedControl!
   @IBOutlet weak private var isWorkIntervalOnSwitch: UISwitch!
 
+  private static let defaultNumBurstSinesPercent = 0.75
+
   private static let maxEnergyViewPowerInWatts = 5.0
   private static let powerLabelUpdateInterval = 0.5
 
@@ -109,6 +111,12 @@ class ViewController: UITableViewController {
     numProcessingThreadsSlider.maximumValue = Float(numberOfProcessors)
 
     syncControlsToEngine()
+
+    // Set the default number of burst sines after syncControlsToEngine(), which sets the
+    // slider's maximum
+    numBurstSinesSlider.value =
+      (Float(engine.maxNumSines) * Float(ViewController.defaultNumBurstSinesPercent))
+        .rounded()
   }
 
   private func setupDriveDurationsView() {

--- a/AudioPerfLab/ViewController.swift
+++ b/AudioPerfLab/ViewController.swift
@@ -78,6 +78,7 @@ class ViewController: UITableViewController {
     UIColor.systemPurple,
     UIColor.systemRed,
     UIColor.systemYellow,
+    UIColor.systemTeal,
   ]
 
   override func viewDidLoad() {
@@ -364,6 +365,10 @@ class ViewController: UITableViewController {
       color: color)
   }
 
+  static func colorForThread(_ threadIndex: Int) -> UIColor {
+    return ViewController.threadColors[threadIndex % ViewController.threadColors.count]
+  }
+
   private func addWorkDistributionMeasurement(
     time: Double,
     duration bufferDuration: Double,
@@ -385,7 +390,7 @@ class ViewController: UITableViewController {
         let percent =
           Double(partialsProcessed) / Double(totalNumActivePartialsProcessed)
         let value = percent + lastValue
-        let color = ViewController.threadColors[threadIndex]
+        let color = ViewController.colorForThread(threadIndex)
         workActivityView.addSample(
           time: time,
           duration: bufferDuration,
@@ -404,7 +409,7 @@ class ViewController: UITableViewController {
     for (cpuNumber, coreActivityView) in coreActivityViews.enumerated() {
       let threadIndex = threadIndexPerCpu[cpuNumber]
       let color =
-        threadIndex != nil ? ViewController.threadColors[threadIndex!] : UIColor.white
+        threadIndex != nil ? ViewController.colorForThread(threadIndex!) : UIColor.white
       coreActivityView.addSample(
         time: time,
         duration: bufferDuration,

--- a/AudioPerfLab/ViewController.swift
+++ b/AudioPerfLab/ViewController.swift
@@ -105,6 +105,7 @@ class ViewController: UITableViewController {
       { (value: Float) in return "\(Int(value * 1000))ms"}
 
     numSinesSlider.minimumValue = Float(engine.numSines)
+    numProcessingThreadsSlider.maximumValue = Float(numberOfProcessors)
 
     syncControlsToEngine()
   }

--- a/AudioPerfLab/ViewController.swift
+++ b/AudioPerfLab/ViewController.swift
@@ -190,12 +190,6 @@ class ViewController: UITableViewController {
     presetChooser.preset = engine.preset
   }
 
-  private func updateNumEngineWorkerThreads() {
-    engine.numWorkerThreads =
-      Int32(numProcessingThreadsSlider.value) - (engine.processInDriverThread ? 1 : 0)
-    updateThreadDependentControls()
-  }
-
   @IBAction private func presetChanged(_ sender: Any) {
     engine.preset = presetChooser.preset
     syncControlsToEngine()
@@ -244,7 +238,8 @@ class ViewController: UITableViewController {
   }
 
   @IBAction private func numProcessingThreadsChanged(_ sender: Any) {
-    updateNumEngineWorkerThreads()
+    engine.numProcessingThreads = Int32(numProcessingThreadsSlider.value)
+    updateThreadDependentControls()
     updatePresetControl()
   }
 
@@ -278,7 +273,7 @@ class ViewController: UITableViewController {
 
   @IBAction private func processInDriverThreadChanged(_ sender: Any) {
     engine.processInDriverThread = processInDriverThreadControl.selectedSegmentIndex == 1
-    updateNumEngineWorkerThreads()
+    updateThreadDependentControls()
     updatePresetControl()
   }
 
@@ -507,14 +502,6 @@ class ViewController: UITableViewController {
       inputMeterView.levelInDb = inputMeterSmoother.smoothedLevel(
         displayTime: displayLink.timestamp)
       redrawExpandedActivityViews()
-    }
-  }
-}
-
-extension Engine {
-  var numProcessingThreads: Int {
-    get {
-      return Int(numWorkerThreads + (processInDriverThread ? 1 : 0))
     }
   }
 }

--- a/Base/AudioHost.cpp
+++ b/Base/AudioHost.cpp
@@ -115,7 +115,7 @@ void AudioHost::setPreferredBufferSize(const int preferredBufferSize)
   }
 }
 
-int AudioHost::numWorkerThreads() const { return int(mWorkerThreads.size()); }
+int AudioHost::numWorkerThreads() const { return mNumWorkerThreads; }
 void AudioHost::setNumWorkerThreads(const int numWorkerThreads)
 {
   if (numWorkerThreads != mNumWorkerThreads)

--- a/Base/AudioHost.cpp
+++ b/Base/AudioHost.cpp
@@ -38,12 +38,18 @@ AudioHost::AudioHost(Setup setup,
   , mRenderEnded{std::move(renderEnded)}
 {
   setupDriver(Driver::Config{});
+  mNumProcessingThreads =
+    kStandardPerformanceConfig.audioHost.numProcessingThreads.value_or(
+      mAudioWorkgroup->maxNumParallelThreads());
 }
 
 AudioHost::~AudioHost() { stop(); }
 
 Driver& AudioHost::driver() { return *mDriver; }
 const Driver& AudioHost::driver() const { return *mDriver; }
+
+SomeAudioWorkgroup& AudioHost::workgroup() { return *mAudioWorkgroup; }
+const SomeAudioWorkgroup& AudioHost::workgroup() const { return *mAudioWorkgroup; }
 
 void AudioHost::start()
 {
@@ -81,7 +87,8 @@ void AudioHost::setConfig(const AudioHostConfig& newConfig)
   if (newConfig != config())
   {
     whileStopped([&] {
-      mNumProcessingThreads = newConfig.numProcessingThreads;
+      mNumProcessingThreads =
+        newConfig.numProcessingThreads.value_or(mAudioWorkgroup->maxNumParallelThreads());
       mProcessInDriverThread = newConfig.processInDriverThread;
       mIsWorkIntervalOn = newConfig.isWorkIntervalOn;
       mMinimumLoad = newConfig.minimumLoad;

--- a/Base/AudioHost.cpp
+++ b/Base/AudioHost.cpp
@@ -49,7 +49,7 @@ void AudioHost::start()
 {
   if (!mIsStarted)
   {
-    mSetup(mNumRequestedWorkerThreads);
+    mSetup(mNumWorkerThreads);
 
     setupWorkerThreads();
     driver().start();
@@ -81,7 +81,7 @@ void AudioHost::setConfig(const AudioHostConfig& newConfig)
   if (newConfig != config())
   {
     whileStopped([&] {
-      mNumRequestedWorkerThreads = newConfig.numWorkerThreads;
+      mNumWorkerThreads = newConfig.numWorkerThreads;
       mProcessInDriverThread = newConfig.processInDriverThread;
       mIsWorkIntervalOn = newConfig.isWorkIntervalOn;
       mMinimumLoad = newConfig.minimumLoad;
@@ -118,9 +118,9 @@ void AudioHost::setPreferredBufferSize(const int preferredBufferSize)
 int AudioHost::numWorkerThreads() const { return int(mWorkerThreads.size()); }
 void AudioHost::setNumWorkerThreads(const int numWorkerThreads)
 {
-  if (numWorkerThreads != mNumRequestedWorkerThreads)
+  if (numWorkerThreads != mNumWorkerThreads)
   {
-    whileStopped([&] { mNumRequestedWorkerThreads = numWorkerThreads; });
+    whileStopped([&] { mNumWorkerThreads = numWorkerThreads; });
   }
 }
 
@@ -187,7 +187,7 @@ void AudioHost::setupWorkerThreads()
                 "Worker threads must be torn down before calling setupWorkerThreads()");
 
   mAreWorkerThreadsActive = true;
-  for (int i = 1; i <= mNumRequestedWorkerThreads; ++i)
+  for (int i = 1; i <= mNumWorkerThreads; ++i)
   {
     mWorkerThreads.emplace_back(&AudioHost::workerThread, this, i);
   }

--- a/Base/AudioHost.hpp
+++ b/Base/AudioHost.hpp
@@ -63,6 +63,9 @@ public:
   Driver& driver();
   const Driver& driver() const;
 
+  SomeAudioWorkgroup& workgroup();
+  const SomeAudioWorkgroup& workgroup() const;
+
   void start();
   void stop();
 
@@ -129,5 +132,5 @@ private:
   RenderEnded mRenderEnded;
 
   bool mIsStarted{false};
-  int mNumProcessingThreads{kStandardPerformanceConfig.audioHost.numProcessingThreads};
+  int mNumProcessingThreads{-1};
 };

--- a/Base/AudioHost.hpp
+++ b/Base/AudioHost.hpp
@@ -47,7 +47,7 @@ class AudioHost
   using Clock = std::chrono::high_resolution_clock;
 
 public:
-  using Setup = std::function<void(int numWorkerThreads)>;
+  using Setup = std::function<void(int numProcessingThreads)>;
   using RenderStarted =
     std::function<void(StereoAudioBufferPtrs ioBuffer, int numFrames)>;
   using Process = std::function<void(int threadIndex, int numFrames)>;
@@ -76,7 +76,9 @@ public:
   void setPreferredBufferSize(const int preferredBufferSize);
 
   int numWorkerThreads() const;
-  void setNumWorkerThreads(int numWorkerThreads);
+
+  int numProcessingThreads() const;
+  void setNumProcessingThreads(int numProcessingThreads);
 
   bool processInDriverThread() const;
   void setProcessInDriverThread(bool isEnabled);
@@ -127,5 +129,5 @@ private:
   RenderEnded mRenderEnded;
 
   bool mIsStarted{false};
-  int mNumWorkerThreads{kStandardPerformanceConfig.audioHost.numWorkerThreads};
+  int mNumProcessingThreads{kStandardPerformanceConfig.audioHost.numProcessingThreads};
 };

--- a/Base/AudioHost.hpp
+++ b/Base/AudioHost.hpp
@@ -127,5 +127,5 @@ private:
   RenderEnded mRenderEnded;
 
   bool mIsStarted{false};
-  int mNumRequestedWorkerThreads{kStandardPerformanceConfig.audioHost.numWorkerThreads};
+  int mNumWorkerThreads{kStandardPerformanceConfig.audioHost.numWorkerThreads};
 };

--- a/Base/AudioWorkgroup.hpp
+++ b/Base/AudioWorkgroup.hpp
@@ -42,6 +42,16 @@ public:
   AudioWorkgroup& operator=(const AudioWorkgroup&);
   ~AudioWorkgroup();
 
+  /*! The system's recommendation for the maximum number of threads that should contribute
+   * to the workload.
+   *
+   * iOS 14, for example, recommends a thread per performance core for the audio I/O
+   * unit's workgroup.
+   *
+   * @see os_workgroup_max_parallel_threads
+   */
+  int maxNumParallelThreads() const;
+
   class ScopedMembership;
 
   /*! Join the current thread to the workgroup. */
@@ -86,6 +96,13 @@ private:
 class LegacyAudioWorkgroup
 {
 public:
+  /*! The system's recommendation for the maximum number of threads that should contribute
+   * to the workload.
+   *
+   * @see pthread_time_constraint_max_parallelism
+   */
+  int maxNumParallelThreads() const;
+
   class ScopedMembership;
 
   /*! Join the current thread to the workgroup. */
@@ -126,6 +143,11 @@ public:
                                         LegacyAudioWorkgroup::ScopedMembership>;
 
   explicit SomeAudioWorkgroup(const WorkgroupVariant& audioWorkgroup);
+
+  /*! The system's recommendation for the maximum number of threads that should contribute
+   * to the workload.
+   */
+  int maxNumParallelThreads() const;
 
   /*! Join the current thread to the workgroup. */
   ScopedMembership join();

--- a/Base/AudioWorkgroup.hpp
+++ b/Base/AudioWorkgroup.hpp
@@ -36,7 +36,7 @@ class AudioWorkgroup
 {
 public:
   API_AVAILABLE(ios(14.0))
-  explicit AudioWorkgroup(os_workgroup_t workgroup);
+  explicit AudioWorkgroup(os_workgroup_t pWorkgroup);
 
   AudioWorkgroup(const AudioWorkgroup&);
   AudioWorkgroup& operator=(const AudioWorkgroup&);
@@ -49,7 +49,7 @@ public:
 
 private:
   DISABLE_AVAILABILITY_WARNINGS
-  os_workgroup_t mWorkgroup;
+  os_workgroup_t mpWorkgroup;
   RESTORE_WARNINGS
 };
 
@@ -71,7 +71,7 @@ private:
   explicit ScopedMembership(os_workgroup_t workgroup);
 
   DISABLE_AVAILABILITY_WARNINGS
-  os_workgroup_t mWorkgroup;
+  os_workgroup_t mpWorkgroup;
   os_workgroup_join_token_s mJoinToken;
   RESTORE_WARNINGS
 

--- a/Base/AudioWorkgroup.mm
+++ b/Base/AudioWorkgroup.mm
@@ -36,10 +36,10 @@
  * included in a C++ TU. Additionally, this file must be Objective-C++.
  */
 
-AudioWorkgroup::ScopedMembership::ScopedMembership(const os_workgroup_t workgroup)
-  : mWorkgroup{workgroup}
+AudioWorkgroup::ScopedMembership::ScopedMembership(const os_workgroup_t pWorkgroup)
+  : mpWorkgroup{pWorkgroup}
 {
-  const auto result = os_workgroup_join(mWorkgroup, &mJoinToken);
+  const auto result = os_workgroup_join(mpWorkgroup, &mJoinToken);
   if (result != 0)
   {
     throw std::runtime_error("Couldn't join the workgroup");
@@ -48,7 +48,7 @@ AudioWorkgroup::ScopedMembership::ScopedMembership(const os_workgroup_t workgrou
 
 AudioWorkgroup::ScopedMembership::ScopedMembership(
   AudioWorkgroup::ScopedMembership&& other)
-  : mWorkgroup{std::exchange(other.mWorkgroup, nullptr)}
+  : mpWorkgroup{std::exchange(other.mpWorkgroup, nullptr)}
   , mJoinToken{other.mJoinToken}
 {
 }
@@ -58,7 +58,7 @@ AudioWorkgroup::ScopedMembership& AudioWorkgroup::ScopedMembership::operator=(
 {
   if (this != &rhs)
   {
-    mWorkgroup = std::exchange(rhs.mWorkgroup, nullptr);
+    mpWorkgroup = std::exchange(rhs.mpWorkgroup, nullptr);
     mJoinToken = rhs.mJoinToken;
   }
   return *this;
@@ -68,9 +68,9 @@ AudioWorkgroup::ScopedMembership::~ScopedMembership()
 {
   if (@available(iOS 14, *))
   {
-    if (mWorkgroup)
+    if (mpWorkgroup)
     {
-      os_workgroup_leave(mWorkgroup, &mJoinToken);
+      os_workgroup_leave(mpWorkgroup, &mJoinToken);
     }
   }
   else
@@ -79,8 +79,8 @@ AudioWorkgroup::ScopedMembership::~ScopedMembership()
   }
 }
 
-AudioWorkgroup::AudioWorkgroup(const os_workgroup_t workgroup)
-  : mWorkgroup{workgroup}
+AudioWorkgroup::AudioWorkgroup(const os_workgroup_t pWorkgroup)
+  : mpWorkgroup{pWorkgroup}
 {
 }
 
@@ -90,7 +90,7 @@ AudioWorkgroup::~AudioWorkgroup() = default;
 
 AudioWorkgroup::ScopedMembership AudioWorkgroup::join()
 {
-  return ScopedMembership{mWorkgroup};
+  return ScopedMembership{mpWorkgroup};
 }
 
 

--- a/Base/Config.hpp
+++ b/Base/Config.hpp
@@ -45,7 +45,7 @@ inline bool operator!=(const BusyThreadsConfig& lhs, const BusyThreadsConfig& rh
 
 struct AudioHostConfig
 {
-  int numWorkerThreads{};
+  int numProcessingThreads{};
   bool processInDriverThread{};
   bool isWorkIntervalOn{};
   double minimumLoad{};
@@ -53,9 +53,9 @@ struct AudioHostConfig
 
 inline bool operator==(const AudioHostConfig& lhs, const AudioHostConfig& rhs)
 {
-  return std::tie(lhs.numWorkerThreads, lhs.processInDriverThread, lhs.isWorkIntervalOn,
-                  lhs.minimumLoad)
-         == std::tie(rhs.numWorkerThreads, rhs.processInDriverThread,
+  return std::tie(lhs.numProcessingThreads, lhs.processInDriverThread,
+                  lhs.isWorkIntervalOn, lhs.minimumLoad)
+         == std::tie(rhs.numProcessingThreads, rhs.processInDriverThread,
                      rhs.isWorkIntervalOn, rhs.minimumLoad);
 }
 
@@ -90,7 +90,7 @@ constexpr auto kStandardPerformanceConfig = PerformanceConfig{
     .cpuUsage = 0.5,
   },
   AudioHostConfig{
-    .numWorkerThreads = 1,
+    .numProcessingThreads = 2,
     .processInDriverThread = true,
     .isWorkIntervalOn = true,
     .minimumLoad = 0.0,
@@ -104,7 +104,7 @@ constexpr auto kOptimalPerformanceConfig = PerformanceConfig{
     .cpuUsage = kStandardPerformanceConfig.busyThreads.cpuUsage,
   },
   AudioHostConfig{
-    .numWorkerThreads = 2,
+    .numProcessingThreads = 2,
     .processInDriverThread = false,
     .isWorkIntervalOn = false,
     .minimumLoad = kStandardPerformanceConfig.audioHost.minimumLoad,

--- a/Base/Config.hpp
+++ b/Base/Config.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <chrono>
+#include <optional>
 #include <tuple>
 
 struct BusyThreadsConfig
@@ -43,9 +44,13 @@ inline bool operator!=(const BusyThreadsConfig& lhs, const BusyThreadsConfig& rh
   return !(lhs == rhs);
 }
 
+constexpr std::optional<int> kUseRecommendedNumThreads = std::nullopt;
+
 struct AudioHostConfig
 {
-  int numProcessingThreads{};
+  // Set to kUseRecommendedNumThreads to use the system's recommended number of threads
+  std::optional<int> numProcessingThreads;
+
   bool processInDriverThread{};
   bool isWorkIntervalOn{};
   double minimumLoad{};
@@ -90,7 +95,7 @@ constexpr auto kStandardPerformanceConfig = PerformanceConfig{
     .cpuUsage = 0.5,
   },
   AudioHostConfig{
-    .numProcessingThreads = 2,
+    .numProcessingThreads = kUseRecommendedNumThreads,
     .processInDriverThread = true,
     .isWorkIntervalOn = true,
     .minimumLoad = 0.0,
@@ -104,7 +109,7 @@ constexpr auto kOptimalPerformanceConfig = PerformanceConfig{
     .cpuUsage = kStandardPerformanceConfig.busyThreads.cpuUsage,
   },
   AudioHostConfig{
-    .numProcessingThreads = 2,
+    .numProcessingThreads = kUseRecommendedNumThreads,
     .processInDriverThread = false,
     .isWorkIntervalOn = false,
     .minimumLoad = kStandardPerformanceConfig.audioHost.minimumLoad,

--- a/Base/Thread.cpp
+++ b/Base/Thread.cpp
@@ -28,6 +28,7 @@
 #include <mach/thread_act.h>
 #include <mach/thread_policy.h>
 #include <os/log.h>
+#include <sys/sysctl.h>
 #include <system_error>
 
 static const mach_timebase_info_data_t sMachTimebaseInfo = [] {
@@ -53,6 +54,15 @@ std::chrono::duration<double> machAbsoluteTimeToSeconds(const uint64_t machAbsol
 }
 
 void setCurrentThreadName(const std::string& name) { pthread_setname_np(name.c_str()); }
+
+std::optional<int32_t> numPhysicalCpus()
+{
+  int32_t result = 0;
+  size_t size = sizeof(int32_t);
+  return sysctlbyname("hw.physicalcpu", &result, &size, nullptr, 0) == 0
+           ? std::optional<int32_t>{result}
+           : std::nullopt;
+}
 
 void setThreadTimeConstraintPolicy(const pthread_t thread,
                                    const TimeConstraintPolicy& timeConstraintPolicy)

--- a/Base/Thread.cpp
+++ b/Base/Thread.cpp
@@ -97,8 +97,10 @@ void setThreadTimeConstraintPolicy(const pthread_t thread,
   policy.preemptible = 1;
 
   os_log(OS_LOG_DEFAULT,
-         "Setting time constraint policy: (period: %d, computation: %d, constraint: %d)",
-         policy.period, policy.computation, policy.constraint);
+         "Setting time constraint policy for %s: "
+         "(period: %d, computation: %d, constraint: %d)",
+         currentThreadName().c_str(), policy.period, policy.computation,
+         policy.constraint);
 
   const kern_return_t result = thread_policy_set(
     pthread_mach_thread_np(thread), THREAD_TIME_CONSTRAINT_POLICY,

--- a/Base/Thread.hpp
+++ b/Base/Thread.hpp
@@ -34,6 +34,7 @@
 uint64_t secondsToMachAbsoluteTime(std::chrono::duration<double> duration);
 std::chrono::duration<double> machAbsoluteTimeToSeconds(uint64_t machTime);
 
+std::string currentThreadName();
 void setCurrentThreadName(const std::string& name);
 
 //! Return the number of physical cores available (not including hyperthreading)

--- a/Base/Thread.hpp
+++ b/Base/Thread.hpp
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <chrono>
+#include <optional>
 #include <pthread.h>
 #include <string>
 
@@ -34,6 +35,9 @@ uint64_t secondsToMachAbsoluteTime(std::chrono::duration<double> duration);
 std::chrono::duration<double> machAbsoluteTimeToSeconds(uint64_t machTime);
 
 void setCurrentThreadName(const std::string& name);
+
+//! Return the number of physical cores available (not including hyperthreading)
+std::optional<int32_t> numPhysicalCpus();
 
 struct TimeConstraintPolicy
 {

--- a/Base/VolumeFader.hpp
+++ b/Base/VolumeFader.hpp
@@ -35,7 +35,8 @@ public:
 
   explicit VolumeFader(const T initialAmp)
     : mRampedValue{initialAmp}
-  {}
+  {
+  }
 
   void fadeTo(const T& amp, const uint64_t numFrames)
   {

--- a/Base/Warnings.hpp
+++ b/Base/Warnings.hpp
@@ -22,8 +22,8 @@
 
 #pragma once
 
-#define DISABLE_AVAILABILITY_WARNINGS \
-  _Pragma("clang diagnostic push") \
-  _Pragma("clang diagnostic ignored \"-Wunguarded-availability-new\"")
+#define DISABLE_AVAILABILITY_WARNINGS                                                    \
+  _Pragma("clang diagnostic push")                                                       \
+    _Pragma("clang diagnostic ignored \"-Wunguarded-availability-new\"")
 
 #define RESTORE_WARNINGS _Pragma("clang diagnostic pop")


### PR DESCRIPTION
Use better defaults when running on an iPad Pro.

* Use the workgroup's recommended number of threads by default. This results in four processing threads by default on a 2020 iPad Pro (one per P-Core) rather than a hard-coded default of two.
* Use the number of processors to set the max value of the processing threads slider. This allows eight processing threads to be used on an iPad Pro rather than the hard-coded max of six.
* Use a heuristic based on the number of P-Cores to set a good max value for the sine waves slider (a good maximum uses the full processing power of the device). This allows the iPad Pro to be tested at full CPU utilization.
* Set the number of burst waves dynamically as well (to 90% of the max number of sine waves).