### PR TITLE
Fix a crash when using the Simulator in Xcode 12

### DIFF
--- a/Base/AudioHost.cpp
+++ b/Base/AudioHost.cpp
@@ -182,14 +182,15 @@ void AudioHost::setupDriver(const Driver::Config config)
 
   if (__builtin_available(iOS 14, *))
   {
-    const auto workgroup = driver().workgroup();
-    assertRelease(workgroup != std::nullopt, "Couldn't retrieve the workgroup");
-    mAudioWorkgroup.emplace(*workgroup);
+    if (const auto maybeWorkgroup = driver().workgroup())
+    {
+      mAudioWorkgroup.emplace(*maybeWorkgroup);
+      return;
+    }
   }
-  else
-  {
-    mAudioWorkgroup.emplace(LegacyAudioWorkgroup{});
-  }
+
+  // Fallback to the legacy workgroup
+  mAudioWorkgroup.emplace(LegacyAudioWorkgroup{});
 }
 
 void AudioHost::teardownDriver()

--- a/Base/AudioWorkgroup.mm
+++ b/Base/AudioWorkgroup.mm
@@ -82,6 +82,7 @@ AudioWorkgroup::ScopedMembership::~ScopedMembership()
 AudioWorkgroup::AudioWorkgroup(const os_workgroup_t pWorkgroup)
   : mpWorkgroup{pWorkgroup}
 {
+  assertRelease(pWorkgroup != nullptr, "nullptr workgroup");
 }
 
 AudioWorkgroup::AudioWorkgroup(const AudioWorkgroup&) = default;

--- a/Base/Driver.mm
+++ b/Base/Driver.mm
@@ -179,14 +179,14 @@ void Driver::setOutputVolume(const float volume, const Seconds fadeDuration)
 
 std::optional<AudioWorkgroup> Driver::workgroup() const
 {
-  os_workgroup_t workgroup;
+  os_workgroup_t pWorkgroup;
   UInt32 size = sizeof(os_workgroup_t);
   const auto result =
     AudioUnitGetProperty(mpRemoteIoUnit, kAudioOutputUnitProperty_OSWorkgroup,
-                         kAudioUnitScope_Global, 0, &workgroup, &size);
+                         kAudioUnitScope_Global, 0, &pWorkgroup, &size);
   if (result == noErr)
   {
-    return AudioWorkgroup{workgroup};
+    return AudioWorkgroup{pWorkgroup};
   }
   else
   {

--- a/Base/Driver.mm
+++ b/Base/Driver.mm
@@ -179,7 +179,7 @@ void Driver::setOutputVolume(const float volume, const Seconds fadeDuration)
 
 std::optional<AudioWorkgroup> Driver::workgroup() const
 {
-  os_workgroup_t pWorkgroup;
+  os_workgroup_t pWorkgroup = nullptr;
   UInt32 size = sizeof(os_workgroup_t);
   const auto result =
     AudioUnitGetProperty(mpRemoteIoUnit, kAudioOutputUnitProperty_OSWorkgroup,

--- a/Base/Driver.mm
+++ b/Base/Driver.mm
@@ -184,7 +184,7 @@ std::optional<AudioWorkgroup> Driver::workgroup() const
   const auto result =
     AudioUnitGetProperty(mpRemoteIoUnit, kAudioOutputUnitProperty_OSWorkgroup,
                          kAudioUnitScope_Global, 0, &pWorkgroup, &size);
-  if (result == noErr)
+  if (result == noErr && pWorkgroup != nullptr)
   {
     return AudioWorkgroup{pWorkgroup};
   }


### PR DESCRIPTION
Due to the RemoteIO Unit returning a `nullptr` workgroup.